### PR TITLE
Fix TypeError if there is only one meeting active

### DIFF
--- a/bigbluebutton_api_python/responses/getmeetings.py
+++ b/bigbluebutton_api_python/responses/getmeetings.py
@@ -1,5 +1,6 @@
 from .base import BaseResponse
 from ..core.meeting import Meeting
+import jxmlease
 
 class GetMeetingsResponse(BaseResponse):
     def get_meetings(self):
@@ -11,6 +12,10 @@ class GetMeetingsResponse(BaseResponse):
         except KeyError:
             pass
 
-        for meetingXml in self.get_field("meetings")["meeting"]:
-            meetings.append(Meeting(meetingXml))
+        meetings_data = self.get_field("meetings")["meeting"]
+        if isinstance(meetings_data, jxmlease.dictnode.XMLDictNode):
+            meetings.append(Meeting(meetings_data))
+        else:
+            for meetingXml in self.get_field("meetings")["meeting"]:
+                meetings.append(Meeting(meetingXml))
         return meetings


### PR DESCRIPTION
If there was only one meeting active in the BBB server, an IndexError exception is raised:

TypeError: string indices must be integers

This patch fixes this error.