### PR TITLE
Fix a couple of issues

### DIFF
--- a/bigbluebutton_api_python/bigbluebutton.py
+++ b/bigbluebutton_api_python/bigbluebutton.py
@@ -72,12 +72,7 @@ class BigBlueButton:
         response = self.__send_api_request(ApiMethod.GET_MEETINGS)
         return GetMeetingsResponse(response)
 
-    def get_recordings(self, meeting_id="", recording_id="", states=None, meta=None):
-        if states:
-            for state in states:
-                if state not in ["processing", "processed", "published", "unpublished", "deleted"]:
-                    raise BBBException("invalidRecordingState", "Invalid recording state given.")
-        params = {"meetingID": meeting_id, "recordID": recording_id}
+    def get_recordings(self, params={}, meta={}):
         if meta:
             for key, val in meta.items():
                 params["meta_" + key] = val
@@ -128,7 +123,7 @@ class BigBlueButton:
 
     def __send_api_request(self, api_call, params={}, data=None):
         url = self.__urlBuilder.buildUrl(api_call, params)
-
+        
         # if data is none, then we send a GET request, if not, then we send a POST request
         if data is None:
             response = urlopen(url, timeout=10).read()

--- a/bigbluebutton_api_python/util/urlbuilder.py
+++ b/bigbluebutton_api_python/util/urlbuilder.py
@@ -1,18 +1,11 @@
 
 from hashlib import sha1
-from re import match
+from re import sub
 
 class UrlBuilder:
     def __init__(self, bbbServerBaseUrl, securitySalt):
-        if not match('/[http|https]:\/\/[a-zA-Z1-9.]*\/bigbluebutton\/api\//', bbbServerBaseUrl):
-            if not bbbServerBaseUrl.startswith("http://") and not bbbServerBaseUrl.startswith("https://"):
-                bbbServerBaseUrl = "http://" + bbbServerBaseUrl
-            if not bbbServerBaseUrl.endswith("/bigbluebutton/api/"):
-                bbbServerBaseUrl = bbbServerBaseUrl[:(bbbServerBaseUrl.find("/", 8)
-                    if bbbServerBaseUrl.find("/", 8) != -1 else len(bbbServerBaseUrl))] + "/bigbluebutton/api/"
-
-        self.securitySalt         = securitySalt
-        self.bbbServerBaseUrl     = bbbServerBaseUrl
+        self.bbbServerBaseUrl = sub('(\/api)?\/?$', '/api/', bbbServerBaseUrl, 1)
+        self.securitySalt = securitySalt
 
     def buildUrl(self, api_call, params={}):
         url = self.bbbServerBaseUrl


### PR DESCRIPTION
I was having issues using the api to get recording URLs. Turns out two things were happening:
On one hand my URL was getting destroyed because it didn't end with `/bigbluebutton/api`, so the requests were going to the wrong place.
Then I was also forced to provide an optional param `meeting_id`, which I do not have.

Fixed those two issues with this pull request