### PR TITLE
Update urlbuilder.py

### DIFF
--- a/bigbluebutton_api_python/util/urlbuilder.py
+++ b/bigbluebutton_api_python/util/urlbuilder.py
@@ -1,11 +1,28 @@
 
 from hashlib import sha1
-from re import sub
+from re import match
+
+import sys
+if sys.version_info[0] == 2:
+    from urllib import quote_plus
+else:
+    try:
+        from urllib.request import quote_plus
+    except:
+        from urllib.parse import quote_plus
+
 
 class UrlBuilder:
     def __init__(self, bbbServerBaseUrl, securitySalt):
-        self.bbbServerBaseUrl = sub('(\/api)?\/?$', '/api/', bbbServerBaseUrl, 1)
-        self.securitySalt = securitySalt
+        if not match('/[http|https]:\/\/[a-zA-Z1-9.]*\/bigbluebutton\/api\//', bbbServerBaseUrl):
+            if not bbbServerBaseUrl.startswith("http://") and not bbbServerBaseUrl.startswith("https://"):
+                bbbServerBaseUrl = "http://" + bbbServerBaseUrl
+            if not bbbServerBaseUrl.endswith("/bigbluebutton/api/"):
+                bbbServerBaseUrl = bbbServerBaseUrl[:(bbbServerBaseUrl.find("/", 8)
+                    if bbbServerBaseUrl.find("/", 8) != -1 else len(bbbServerBaseUrl))] + "/bigbluebutton/api/"
+
+        self.securitySalt         = securitySalt
+        self.bbbServerBaseUrl     = bbbServerBaseUrl
 
     def buildUrl(self, api_call, params={}):
         url = self.bbbServerBaseUrl
@@ -15,7 +32,7 @@ class UrlBuilder:
                 value = "true" if value else "false"
             else:
                 value = str(value)
-            url += key + "=" + value + "&"
+            url += key + "=" + quote_plus(value) + "&"
 
         url += "checksum=" + self.__get_checksum(api_call, params)
         return url
@@ -27,7 +44,7 @@ class UrlBuilder:
                 value = "true" if value else "false"
             else:
                 value = str(value)
-            secret_str += key + "=" + value + "&"
+            secret_str += key + "=" + quote_plus(value) + "&"
         if secret_str.endswith("&"):
             secret_str = secret_str[:-1]
         secret_str += self.securitySalt

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='bigbluebutton_api_python',
-      version='0.0.9',
+      version='0.0.12',
       description='Python library that provides access to the API of BigBlueButton',
       author='Tarek Kalaji, Yunkai Wang',
       author_email='yunkai.wang@blindsidenetworks.com',


### PR DESCRIPTION
Quote the URLs. BBB does not accept unquoted meeting ids like containing [] as is the case with Moodle. This code is copied directly from the pip archive which has these changes applied but does not have other changes only found in this repo.