### PR TITLE
fix: problem when no user attend the meeting

### DIFF
--- a/bigbluebutton_api_python/core/attendance.py
+++ b/bigbluebutton_api_python/core/attendance.py
@@ -5,7 +5,8 @@ class Attendance:
         self.__startTime = xml["createdOn"]
         self.__endTime = xml["endedOn"]
         self.__users = {}
-        self.set_users(xml)
+        if xml.get("users", []):
+            self.set_users(xml)
 
     def set_users(self, xml):
         for user in xml["users"]:


### PR DESCRIPTION
when no user attend the meetings, the big blue button response do not have the "users" key
that lead to key Error Exception, to solve that, we need to verify if the meeting has users or not