### PR TITLE
fix bug in big blue button , by doing a wrok arround

### DIFF
--- a/bigbluebutton_api_python/responses/getattendance.py
+++ b/bigbluebutton_api_python/responses/getattendance.py
@@ -10,6 +10,9 @@ class GetAttendanceResponse(BaseResponse):
             super().__init__(xml)
     def get_attendance(self):
         attendances = []
-        for meeting in self.get_field("meetings")["meeting"]:
+        meetings = self.get_field("meetings")["meeting"]
+        if type(meetings) != list:
+            meetings = [meetings]
+        for meeting in list(self.get_field("meetings")["meeting"]):
             attendances.append(Attendance(xml=meeting))
         return attendances


### PR DESCRIPTION
it supposed that the meetings response is a list of meetings,
but i found out that if there is only meeting,
big blue button return just the meeting object instead of : put it inside a list,
i made a small work around to place that meeting inside a list if it has only one meeting